### PR TITLE
use bind_s to avoid ldap server busy

### DIFF
--- a/mutt_ldap.py
+++ b/mutt_ldap.py
@@ -195,7 +195,7 @@ class LDAPConnection (object):
             sasl = _ldap_sasl.gssapi()
             self.connection.sasl_interactive_bind_s('', sasl)
         else:
-            self.connection.bind(
+            self.connection.bind_s(
                 self.config.get('auth', 'user'),
                 self.config.get('auth', 'password'),
                 _ldap.AUTH_SIMPLE)


### PR DESCRIPTION
Using bind_s will serialize the interactions with ldap server.
Otherwise it may fail with error like this:
{'info': '00002024: LdapErr: DSID-0C060595, comment: No other operations may be performed on the connection while a bind is outstanding., data 0, v1772', 'desc': 'Server is busy'}